### PR TITLE
README.md: fix nbextension setup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation
 To install use pip:
 
     $ pip install jupyter-aas-timeseries
-    $ jupyter nbextension enable --py --sys-prefix jupyter-aas-timeseries
+    $ jupyter nbextension enable --py --sys-prefix jupyter_aas_timeseries
 
 
 Development workflow
@@ -20,8 +20,8 @@ For a development installation (requires npm),
     $ git clone https://github.com/aperiosoftware/jupyter-aas-timeseries.git
     $ cd jupyter-aas-timeseries
     $ pip install -e .
-    $ jupyter nbextension install --py --symlink --sys-prefix jupyter-aas-timeseries
-    $ jupyter nbextension enable --py --sys-prefix jupyter-aas-timeseries
+    $ jupyter nbextension install --py --symlink --sys-prefix jupyter_aas_timeseries
+    $ jupyter nbextension enable --py --sys-prefix jupyter_aas_timeseries
 
 If you make any changes to the Python code, you do not have to run these
 commands again but you will need to restart the kernel from the notebook.


### PR DESCRIPTION
The `jupyter nbextension` commands take a module name, not a package name, so we need to change the hyphens to underscores.

CC @gregschwarz.